### PR TITLE
Add support to 1.19.1 & Bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 .idea/
+
+# workload directory
+tmp/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can manage the build distributions with some uncommenting (removing `//`) an
 If you didn't, just install Java 17. That's the default.   
 Don't forget to add their `bin` directory to `PATH`!
     > *Note: You don't have to configure this if you've set up the IDE.*
-4. Do `gradlew build`.
+4. Do `gradlew build`. Note that you can also use `gradlew jar`.
     > OS-specific:
     > * Windows CMD: `gradlew.bat build`
     > * Windows Powershell: `.\gradlew.bat build`

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-## patcher
+## Arclight Plugin Patcher
+
+**NOTE**: This repository only contains the WorldEdit-related patch.   
+You'll have to code it yourself, with looking through Arclight API & Spigot API,   
+if you want to patch other plugins not properly working on Arclight.
+
+### Get Pre-built Binaries
+
+Head to Releases, and grab some.   
+You should make your own build if you're using customized server.   
+(for example, your server is at 1.15.2)
+
+Please note that this binary would support you **only when you're on Java 17**.
+
+### Update Instructions
+
+**WARN**: If you don't remove `{server-root}/.arclight/patcher` directory, the new patch won't apply! 
+
+1. You want to replace plugin file, so you *must* stop the server first.
+2. Drop `patcher-loader-(version).jar` in `plugins`.
+3. Head to `.arclight`. This will exist on the root of the server.
+4. Remove `patcher` directory. If you don't remove it, the new patch won't be applied.
+5. Now you can start the server. 
+
+### Build
+
+The build uses Spigot-API, so you don't have to build it with buildtools.   
+However, if an error arises, try building it again with done with buidtools.   
+If you're using prebuilt spigot binary on your PC,   
+add `mavenLocal()` to the repositories in `patcher-loader/build.gradle`.
+
+1. You'll want to make your clone _(you can download the source code too)_ of this repo.   
+I'll recommend creating your own fork before cloning, and work on that fork.
+2. If you want to customize it, you'll want to head up to two `build.gradle`, one at the root and the other in `patcher-loader`.   
+You can manage the build distributions with some uncommenting (removing `//`) and commenting (adding `//` at the very first of the very line).   
+    > **WARN**: If two-or-more definition of Spigot-API or Java Version exists, the build can fail. Implement *only* one Spigot-API, and define *only* one JAVA version!   
+    **Note**: If you want to customize it out of the code, you'll have to add your own version of Spigot-API. Further, you'll have to check the build number(like `R0.1`) to successfully configure it.
+3. You'll want to grab some Java JDK, according to the setup on `build.gradle` of the root.   
+If you didn't, just install Java 17. That's the default.   
+Don't forget to add their `bin` directory to `PATH`!
+    > *Note: You don't have to configure this if you've set up the IDE.*
+4. Do `gradlew build`.
+    > OS-specific:
+    > * Windows CMD: `gradlew.bat build`
+    > * Windows Powershell: `.\gradlew.bat build`
+    > * Bash: `./gradlew build`
+5. Grab plugin in `patcher-loader/build/libs`.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@ if you want to patch other plugins not properly working on Arclight.
 
 ### Build
 
-The build uses Spigot-API, so you don't have to build it with buildtools.   
-However, if an error arises, try building it again with done with buidtools.   
-If you're using prebuilt spigot binary on your PC,   
-add `mavenLocal()` to the repositories in `patcher-loader/build.gradle`.
+The build uses Spigot-API, so you don't have to build it with buildtools.
 
-1. You'll want to make your clone _(you can download the source code too)_ of this repo.   
+1. You'll want to make your clone _(don't just download- the build will fail if you just download it)_ of this repo.   
 I'll recommend creating your own fork before cloning, and work on that fork.
 2. If you want to customize it, you'll want to head up to two `build.gradle`, one at the root and the other in `patcher-loader`.   
 You can manage the build distributions with some uncommenting (removing `//`) and commenting (adding `//` at the very first of the very line).   

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@
 You'll have to code it yourself, with looking through Arclight API & Spigot API,   
 if you want to patch other plugins not properly working on Arclight.
 
-### Get Pre-built Binaries
-
-Head to Releases, and grab some.   
-You should make your own build if you're using customized server.   
-(for example, your server is at 1.15.2)
-
-Please note that this binary would support you **only when you're on Java 17**.
-
 ### Update Instructions
 
 **WARN**: If you don't remove `{server-root}/.arclight/patcher` directory, the new patch won't apply! 

--- a/build.gradle
+++ b/build.gradle
@@ -6,5 +6,5 @@ allprojects {
     group 'io.izzel.arclight'
     version '1.0.0'
 
-    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,5 +6,7 @@ allprojects {
     group 'io.izzel.arclight'
     version '1.0.1'
 
-    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
+    //sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8 //for up to 1.16
+    //sourceCompatibility = targetCompatibility = JavaVersion.VERSION_16 //for 1.17 & 1.17.1
+    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17 //for 1.18+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group 'io.izzel.arclight'
-    version '1.0.0'
+    version '1.0.1'
 
     sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/patcher-definition/build.gradle
+++ b/patcher-definition/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.izzel.arclight:arclight-api:1.2.+'
+    implementation 'io.izzel.arclight:arclight-api:1.3.+'
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
     implementation 'org.ow2.asm:asm-commons:9.2'

--- a/patcher-definition/build.gradle
+++ b/patcher-definition/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.izzel.arclight:arclight-api:1.1.+'
+    implementation 'io.izzel.arclight:arclight-api:1.2.+'
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
     implementation 'org.ow2.asm:asm-commons:9.2'

--- a/patcher-definition/src/main/java/io/izzel/arclight/patcher/definition/DefinitionMain.java
+++ b/patcher-definition/src/main/java/io/izzel/arclight/patcher/definition/DefinitionMain.java
@@ -16,6 +16,7 @@ public class DefinitionMain implements PluginPatcher {
 
     static {
         SPECIFIC.put("com/sk89q/worldedit/bukkit/BukkitAdapter", WorldEdit::handleBukkitAdapter);
+        SPECIFIC.put("com/sk89q/worldedit/bukkit/adapter/Refraction", WorldEdit::handlePickName);
         GENERAL.add(WorldEdit::handleGetProperties);
         GENERAL.add(WorldEdit::handleWatchdog);
     }

--- a/patcher-definition/src/main/java/io/izzel/arclight/patcher/definition/WorldEdit.java
+++ b/patcher-definition/src/main/java/io/izzel/arclight/patcher/definition/WorldEdit.java
@@ -50,6 +50,17 @@ public class WorldEdit {
         }
     }
 
+    public static void handlePickName(ClassNode node, PluginPatcher.ClassRepo repo) {
+        for (MethodNode method : node.methods) {
+            if (method.name.equals("pickName")) {
+                method.instructions.clear();
+                method.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                method.instructions.add(new InsnNode(Opcodes.ARETURN));
+                return;
+            }
+        }
+    }
+
     private static void handleAdapt(ClassNode node, MethodNode standardize, MethodNode method) {
         switch (method.desc) {
             case "(Lcom/sk89q/worldedit/world/item/ItemType;)Lorg/bukkit/Material;":

--- a/patcher-loader/build.gradle
+++ b/patcher-loader/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
     //implementation 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
-    implementation 'org.spigotmc:spigot-api:1.19.1-Ro.1-SNAPSHOT'
+    implementation 'org.spigotmc:spigot-api:1.19.1-R0.1-SNAPSHOT'
 }
 
 jar {

--- a/patcher-loader/build.gradle
+++ b/patcher-loader/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'io.izzel.arclight:arclight-api:1.2.+'
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
-    implementation 'org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT'
+    implementation 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
 }
 
 jar {

--- a/patcher-loader/build.gradle
+++ b/patcher-loader/build.gradle
@@ -9,10 +9,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.izzel.arclight:arclight-api:1.1.+'
+    implementation 'io.izzel.arclight:arclight-api:1.2.+'
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
-    implementation 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT'
+    implementation 'org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT'
 }
 
 jar {

--- a/patcher-loader/build.gradle
+++ b/patcher-loader/build.gradle
@@ -12,8 +12,11 @@ dependencies {
     implementation 'io.izzel.arclight:arclight-api:1.2.+'
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
-    //implementation 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
-    implementation 'org.spigotmc:spigot-api:1.19.1-R0.1-SNAPSHOT'
+    //implementation 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT' //for 1.16.5
+    //implementation 'org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT' //for 1.17.1
+    //implementation 'org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT' //for 1.18.1
+    //implementation 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT' //for 1.18.2
+    implementation 'org.spigotmc:spigot-api:1.19.1-R0.1-SNAPSHOT' //for 1.19.1
 }
 
 jar {

--- a/patcher-loader/build.gradle
+++ b/patcher-loader/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     implementation 'io.izzel.arclight:arclight-api:1.2.+'
     implementation 'org.ow2.asm:asm:9.2'
     implementation 'org.ow2.asm:asm-tree:9.2'
-    implementation 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
+    //implementation 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
+    implementation 'org.spigotmc:spigot-api:1.19.1-Ro.1-SNAPSHOT'
 }
 
 jar {

--- a/patcher-loader/src/main/resources/plugin.yml
+++ b/patcher-loader/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArclightPatcher
 main: io.izzel.arclight.patcher.PluginMain
 version: ${version}
-api-version: 1.16
+api-version: 1.18
 arclight:
   patcher: io.izzel.arclight.patcher.PatcherMain

--- a/patcher-loader/src/main/resources/plugin.yml
+++ b/patcher-loader/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArclightPatcher
 main: io.izzel.arclight.patcher.PluginMain
 version: ${version}
-api-version: 1.18
+api-version: 1.19
 arclight:
   patcher: io.izzel.arclight.patcher.PatcherMain


### PR DESCRIPTION
Similar to #2, but you can configure a bit more.
Also you can reuse this simply by configuring some lines in `build.gradle` files and `plugin.yml`.
(Some refactoring would not work on some environment)
Please note you should clone the repository *just* to build the plugin!

Fixes #3 More documentation
Fixes #7 Patcher with update worldedit 7.2
<!--dumb github doesn't contain something parsing multiple issue tags in single line-->

Check out the prebuilt editions [here](https://github.com/ReveTown/Arclight-Plugin-Patcher/releases). This release will receive up-to-date version according to Arclight's ones.
Here's the prebuilt one for [1.16.5](https://github.com/ArclightPowered/patcher/files/9243713/patcher-loader-1.0.0.zip).

Code-level tested on 1.16.5(Binary built by VeroFess), 1.18.1, and 1.18.2.
Please note that each version of the patcher will work only on the specific version.
For example, 1.16.5 version won't load on 1.16.4 or lower, 1.18.1 version won't load on 1.18.2 (but loading 1.18.2 version on 1.18.1 might work), and 1.19.1 version won't load on 1.18.x(test required).